### PR TITLE
Inline proceeding JMP instruction in TEST, TESTSET and TFORLOOP

### DIFF
--- a/gen/gen_template.lua
+++ b/gen/gen_template.lua
@@ -367,9 +367,10 @@ table.move(vals, 1, inst.C, base, stack)
 
 if stack[base] ~= nil then
 	stack[A + 2] = stack[base]
-else
-	pc = pc + 1
+	pc = pc + code[pc].sBx
 end
+
+pc = pc + 1
 
 --[[SETLIST]]
 local A = inst.A

--- a/gen/gen_template.lua
+++ b/gen/gen_template.lua
@@ -251,17 +251,18 @@ if (lhs <= rhs) == (inst.A ~= 0) then pc = pc + code[pc].sBx end
 pc = pc + 1
 
 --[[TEST]]
-if (not memory[inst.A]) == (inst.C ~= 0) then pc = pc + 1 end
+if (not memory[inst.A]) ~= (inst.C ~= 0) then pc = pc + code[pc].sBx end
+pc = pc + 1
 
 --[[TESTSET]]
 local A = inst.A
 local B = inst.B
 
-if (not memory[B]) == (inst.C ~= 0) then
-	pc = pc + 1
-else
+if (not memory[B]) ~= (inst.C ~= 0) then
 	memory[A] = memory[B]
+	pc = pc + code[pc].sBx
 end
+pc = pc + 1
 
 --[[CALL]]
 local A = inst.A

--- a/source.lua
+++ b/source.lua
@@ -1018,9 +1018,10 @@ local function run_lua_func(state, env, upvals)
 
 				if memory[base] ~= nil then
 					memory[A + 2] = memory[base]
-				else
-					pc = pc + 1
+					pc = pc + code[pc].sBx
 				end
+
+				pc = pc + 1
 			end
 		else
 			--[[JMP]]

--- a/source.lua
+++ b/source.lua
@@ -935,11 +935,11 @@ local function run_lua_func(state, env, upvals)
 							local A = inst.A
 							local B = inst.B
 
-							if (not memory[B]) == (inst.C ~= 0) then
-								pc = pc + 1
-							else
+							if (not memory[B]) ~= (inst.C ~= 0) then
 								memory[A] = memory[B]
+								pc = pc + code[pc].sBx
 							end
+							pc = pc + 1
 						end
 					else
 						--[[UNM]]
@@ -997,7 +997,8 @@ local function run_lua_func(state, env, upvals)
 					end
 				else
 					--[[TEST]]
-					if (not memory[inst.A]) == (inst.C ~= 0) then pc = pc + 1 end
+					if (not memory[inst.A]) ~= (inst.C ~= 0) then pc = pc + code[pc].sBx end
+					pc = pc + 1
 				end
 			else
 				--[[TFORLOOP]]


### PR DESCRIPTION
Have not done extensive testing, but since all TEST, TESTSET, and TFORLOOP instructions are followed by a JMP, this should provide a small micro-optimization.