### PR TITLE
Decode and use NEWTABLE array size argument

### DIFF
--- a/gen/gen_template.lua
+++ b/gen/gen_template.lua
@@ -56,7 +56,7 @@ end
 memory[inst.A][index] = value
 
 --[[NEWTABLE]]
-memory[inst.A] = {}
+memory[inst.A] = table.create(inst.const) -- inst.const contains array size
 
 --[[SELF]]
 local A = inst.A

--- a/source.lua
+++ b/source.lua
@@ -366,6 +366,15 @@ local function stm_inst_list(S)
 			data.sBx = bit.band(bit.rshift(ins, 14), 0x3FFFF) - 131071
 		end
 
+		if op == 10 then -- decode NEWTABLE array size
+			local e = bit.band(bit.rshift(data.B, 3), 31)
+			if (e == 0) then
+				data.const = data.B
+			else
+				data.const = bit.lshift(bit.band(data.B, 7) + 8, e - 1) -- store as constant value
+			end
+		end
+
 		list[i] = data
 	end
 
@@ -730,7 +739,7 @@ local function run_lua_func(state, env, upvals)
 						end
 					elseif op > 16 then
 						--[[NEWTABLE]]
-						memory[inst.A] = {}
+						memory[inst.A] = table.create(inst.const) -- inst.const contains array size
 					else
 						--[[DIV]]
 						local lhs, rhs

--- a/source.lua
+++ b/source.lua
@@ -359,20 +359,20 @@ local function stm_inst_list(S)
 			data.C = bit.band(bit.rshift(ins, 14), 0x1FF)
 			data.is_KB = mode.b == 'OpArgK' and data.B > 0xFF -- post process optimization
 			data.is_KC = mode.c == 'OpArgK' and data.C > 0xFF
+
+			if op == 10 then -- decode NEWTABLE array size, store it as constant value
+				local e = bit.band(bit.rshift(data.B, 3), 31)
+				if e == 0 then
+					data.const = data.B
+				else
+					data.const = bit.lshift(bit.band(data.B, 7) + 8, e - 1)
+				end
+			end
 		elseif args == 'ABx' then
 			data.Bx = bit.band(bit.rshift(ins, 14), 0x3FFFF)
 			data.is_K = mode.b == 'OpArgK'
 		elseif args == 'AsBx' then
 			data.sBx = bit.band(bit.rshift(ins, 14), 0x3FFFF) - 131071
-		end
-
-		if op == 10 then -- decode NEWTABLE array size
-			local e = bit.band(bit.rshift(data.B, 3), 31)
-			if (e == 0) then
-				data.const = data.B
-			else
-				data.const = bit.lshift(bit.band(data.B, 7) + 8, e - 1) -- store as constant value
-			end
 		end
 
 		list[i] = data


### PR DESCRIPTION
I have modified the NEWTABLE opcode to use the B field (array size) as a parameter to `table.create` instead of initializing the table normally.
Logic to decode the "floating point byte" format (described in [lobject.c](https://www.lua.org/source/5.1/lobject.c.html#luaO_int2fb)) has been added to the instruction decoder to support this, setting `inst.const` to the decoded array size.

The C field was disregarded, as `table.create` does not pre-allocate any space for dictionary keys.

This change should provide a performance increase in Luau environments, and the decrease in other environments should be negligible.