### PR TITLE
O(n) instead of O(n^2) string concactenation

### DIFF
--- a/gen/gen_template.lua
+++ b/gen/gen_template.lua
@@ -184,10 +184,14 @@ memory[inst.A] = not memory[inst.B]
 memory[inst.A] = #memory[inst.B]
 
 --[[CONCAT]]
-local B = inst.B
-local str = memory[B]
+local B, C = inst.B, inst.C
+local success, str = pcall(table.concat, memory, "", B, C)
 
-for i = B + 1, inst.C do str = str .. memory[i] end
+if not success then
+	str = memory[B]
+
+	for i = B + 1, C do str = str .. memory[i] end
+end
 
 memory[inst.A] = str
 

--- a/source.lua
+++ b/source.lua
@@ -806,10 +806,14 @@ local function run_lua_func(state, env, upvals)
 							return table.unpack(memory, A, A + len - 1)
 						else
 							--[[CONCAT]]
-							local B = inst.B
-							local str = memory[B]
+							local B, C = inst.B, inst.C
+							local success, str = pcall(table.concat, memory, "", B, C)
 
-							for i = B + 1, inst.C do str = str .. memory[i] end
+							if not success then
+								str = memory[B]
+
+								for i = B + 1, C do str = str .. memory[i] end
+							end
 
 							memory[inst.A] = str
 						end


### PR DESCRIPTION
I'm not sure if this makes sense at all or is this just totally stupid and causes more issues than it solves.

Anyways I'm not sure if this makes sense in real world usecases. It would certainly need to be performance tested