### PR TITLE
Optimize FORLOOP step to constant comparison

### DIFF
--- a/gen/gen_template.lua
+++ b/gen/gen_template.lua
@@ -329,7 +329,7 @@ local index = memory[A] + step
 local limit = memory[A + 1]
 local loops
 
-if step == math.abs(step) then
+if step >= 0 then
 	loops = index <= limit
 else
 	loops = index >= limit

--- a/source.lua
+++ b/source.lua
@@ -770,7 +770,7 @@ local function run_lua_func(state, env, upvals)
 				local limit = memory[A + 1]
 				local loops
 
-				if step == math.abs(step) then
+				if step >= 0 then
 					loops = index <= limit
 				else
 					loops = index >= limit


### PR DESCRIPTION
This converts the math.abs call which even with full Luau optimization is 2 instruction to a simple LE comparison constant check which is 1 instruction.
This provides a speedup for numeric loops. Especially if FiOne is ran in unoptimized Lua environments.
This also works with NaNs.

Before (environment unoptimized):
![image](https://github.com/user-attachments/assets/9e74e634-7120-476b-a41e-796c21022e4e)

Before:
![image](https://github.com/user-attachments/assets/75cfcdf4-97f0-4646-8022-f6034f507430)

After:
![image](https://github.com/user-attachments/assets/d7cace5a-dcd2-4904-ad4a-2c78d222d504)

Script:
```lua
task.wait(9)
local start = os.clock()
local val = tonumber(script.Name)
local t = 0

for i = 1, 7e7 do
	if val >= 0 then -- Before: if val == math.abs(val) then
		t += 1
	end
end

print("Took:", os.clock() - start)
```
