### PR TITLE
Support LUA_COMPAT_VARARG behaviour

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -453,7 +453,7 @@ function stm_lua_func(S, psrc)
 	proto.num_upval = stm_byte(S) -- num upvalues
 	proto.num_param = stm_byte(S) -- num params
 
-	stm_byte(S) -- vararg flag
+	proto.is_vararg = stm_byte(S) -- vararg flag
 	proto.max_stack = stm_byte(S) -- max stack size
 
 	proto.code = stm_inst_list(S)
@@ -465,6 +465,7 @@ function stm_lua_func(S, psrc)
 	stm_upval_list(S)
 
 	-- post process optimization
+	proto.needs_arg = bit.band(proto.is_vararg, 0x5) == 0x5
 	for _, v in ipairs(proto.code) do
 		if v.is_K then
 			v.const = proto.const[v.Bx + 1] -- offset for 1 based index
@@ -1057,6 +1058,10 @@ function lua_wrap_state(proto, env, upval)
 
 			vararg.len = len
 			table.move(passed, start, start + len - 1, 1, vararg.list)
+		end
+
+		if proto.needs_arg then
+			memory[proto.num_param] = {n = vararg.len, table.unpack(vararg.list, 1, vararg.len)}
 		end
 
 		local state = {vararg = vararg, memory = memory, code = proto.code, subs = proto.subs, pc = 1}


### PR DESCRIPTION
Turns out Lua 5.1 has a barely-documented feature where variadic functions will (when the `LUA_COMPAT_VARARG` compatability feature is enabled) just create their own local for the scope, `arg`, which gets set to the equivilant of `table.pack(...)` iff `...` itself isn't used in the body (otherwise it's nil). This implements that behaviour
For reference, 0x5 in terms of is_vararg is `VARARG_HASARG | VARARG_NEEDSARG`
Example function which uses the arg behaviour:
```lua
local function f(arg)
	return function(a, ...)
		print(arg) -- table: <address>
		table.foreach(arg, print)
	end
end
f(2)(1, 2, 3, 4, 5)
```